### PR TITLE
[ADD] all home endpoints

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -59,7 +59,11 @@ func main() {
 	settingsService := service.NewSettingsService(settingsRepo, userService)
 	settingsHandler := http.NewSetingsHandler(settingsService)
 
-	_, err = http.NewRouter(app, *ingredientHandler, *recipeHandler, *authHandler, *stockHandler, *userHandler, *orderHandler, *settingsHandler)
+	homeRepo := repository.NewHomeRepository(client)
+	homeService := service.NewHomeService(homeRepo, userService)
+	homeHandler := http.NewHomeHandler(homeService)
+
+	_, err = http.NewRouter(app, *ingredientHandler, *recipeHandler, *authHandler, *stockHandler, *userHandler, *orderHandler, *settingsHandler, *homeHandler)
 
 	port := config.HTTP.Port
 	if port == "" {

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -64,7 +64,7 @@ func main() {
 	notificationHandler := http.NewNotificationHandler(notificationService)
 
 	homeRepo := repository.NewHomeRepository(client)
-	homeService := service.NewHomeService(homeRepo, userService)
+	homeService := service.NewHomeService(homeRepo, userService, settingsService, recipeRepo, ingredientRepo)
 	homeHandler := http.NewHomeHandler(homeService)
 
 	_, err = http.NewRouter(app, *ingredientHandler, *recipeHandler, *authHandler, *stockHandler, *userHandler, *orderHandler, *settingsHandler, *notificationHandler, *homeHandler)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,46 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/home/getTopProducts": {
+            "post": {
+                "description": "Get top products to display in the intelligent dashboard by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "home"
+                ],
+                "summary": "Get top products to display in the intelligent dashboard",
+                "parameters": [
+                    {
+                        "description": "Filter Request",
+                        "name": "filter_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.FilterSellingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/domain.FilterProductResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot get the filter response.",
+                        "schema": {
+                            "$ref": "#/definitions/http.response"
+                        }
+                    }
+                }
+            }
+        },
         "/home/getUnreadNotification": {
             "get": {
                 "description": "Get unread notification amount of user by user ID",
@@ -1048,6 +1088,60 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.FilterItemResponse": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.FilterProductResponse": {
+            "type": "object",
+            "properties": {
+                "products": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.FilterItemResponse"
+                    }
+                }
+            }
+        },
+        "domain.FilterSellingRequest": {
+            "type": "object",
+            "properties": {
+                "filter_type": {
+                    "type": "string"
+                },
+                "order_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sales_channel": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sort_type": {
+                    "type": "string"
+                },
+                "unit_type": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.FixCostSetting": {
             "type": "object",
             "properties": {
@@ -1346,6 +1440,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "sell_by_date": {
+                    "type": "string"
+                },
+                "stock_detail_id": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,44 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/home/getDashboardChartData": {
+            "get": {
+                "description": "Get data of each chart on dashboard by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "home"
+                ],
+                "summary": "Get data of each chart on dashboard",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/domain.DashboardChartDataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot get data for all charts.",
+                        "schema": {
+                            "$ref": "#/definitions/http.response"
+                        }
+                    }
+                }
+            }
+        },
         "/home/getTopProducts": {
             "post": {
                 "description": "Get top products to display in the intelligent dashboard by user ID",
@@ -1045,6 +1083,23 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.CostRevenueChartItem": {
+            "type": "object",
+            "properties": {
+                "cost": {
+                    "type": "number"
+                },
+                "month": {
+                    "type": "string"
+                },
+                "net_profit": {
+                    "type": "number"
+                },
+                "revenue": {
+                    "type": "number"
+                }
+            }
+        },
         "domain.CreateNotificationItem": {
             "type": "object",
             "properties": {
@@ -1071,6 +1126,29 @@ const docTemplate = `{
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "domain.DashboardChartDataResponse": {
+            "type": "object",
+            "properties": {
+                "cost_revenue": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.CostRevenueChartItem"
+                    }
+                },
+                "net_profit": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.NetProfitChartItem"
+                    }
+                },
+                "profit_threshold": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.ProfitThresholdChartItem"
+                    }
                 }
             }
         },
@@ -1309,6 +1387,17 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.NetProfitChartItem": {
+            "type": "object",
+            "properties": {
+                "month": {
+                    "type": "string"
+                },
+                "profit": {
+                    "type": "number"
+                }
+            }
+        },
         "domain.NotificationItem": {
             "type": "object",
             "properties": {
@@ -1337,6 +1426,17 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/domain.NotificationItem"
                     }
+                }
+            }
+        },
+        "domain.ProfitThresholdChartItem": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "threshold": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,44 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/home/getUnreadNotification": {
+            "get": {
+                "description": "Get unread notification amount of user by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "home"
+                ],
+                "summary": "Get unread notification amount of user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/domain.UnreadNotification"
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot get unread notification amount.",
+                        "schema": {
+                            "$ref": "#/definitions/http.response"
+                        }
+                    }
+                }
+            }
+        },
         "/ingredient/deleteIngredient": {
             "delete": {
                 "description": "Delete an ingredient by using ingredient id",
@@ -1094,6 +1132,14 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/domain.StockItem"
                     }
+                }
+            }
+        },
+        "domain.UnreadNotification": {
+            "type": "object",
+            "properties": {
+                "unread_noti_amount": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9,6 +9,46 @@
     "host": "localhost:8000",
     "basePath": "/api",
     "paths": {
+        "/home/getTopProducts": {
+            "post": {
+                "description": "Get top products to display in the intelligent dashboard by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "home"
+                ],
+                "summary": "Get top products to display in the intelligent dashboard",
+                "parameters": [
+                    {
+                        "description": "Filter Request",
+                        "name": "filter_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.FilterSellingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/domain.FilterProductResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot get the filter response.",
+                        "schema": {
+                            "$ref": "#/definitions/http.response"
+                        }
+                    }
+                }
+            }
+        },
         "/home/getUnreadNotification": {
             "get": {
                 "description": "Get unread notification amount of user by user ID",
@@ -1042,6 +1082,60 @@
                 }
             }
         },
+        "domain.FilterItemResponse": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.FilterProductResponse": {
+            "type": "object",
+            "properties": {
+                "products": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.FilterItemResponse"
+                    }
+                }
+            }
+        },
+        "domain.FilterSellingRequest": {
+            "type": "object",
+            "properties": {
+                "filter_type": {
+                    "type": "string"
+                },
+                "order_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sales_channel": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sort_type": {
+                    "type": "string"
+                },
+                "unit_type": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.FixCostSetting": {
             "type": "object",
             "properties": {
@@ -1340,6 +1434,9 @@
                     "type": "integer"
                 },
                 "sell_by_date": {
+                    "type": "string"
+                },
+                "stock_detail_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9,6 +9,44 @@
     "host": "localhost:8000",
     "basePath": "/api",
     "paths": {
+        "/home/getUnreadNotification": {
+            "get": {
+                "description": "Get unread notification amount of user by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "home"
+                ],
+                "summary": "Get unread notification amount of user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/domain.UnreadNotification"
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot get unread notification amount.",
+                        "schema": {
+                            "$ref": "#/definitions/http.response"
+                        }
+                    }
+                }
+            }
+        },
         "/ingredient/deleteIngredient": {
             "delete": {
                 "description": "Delete an ingredient by using ingredient id",
@@ -1088,6 +1126,14 @@
                     "items": {
                         "$ref": "#/definitions/domain.StockItem"
                     }
+                }
+            }
+        },
+        "domain.UnreadNotification": {
+            "type": "object",
+            "properties": {
+                "unread_noti_amount": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9,6 +9,44 @@
     "host": "localhost:8000",
     "basePath": "/api",
     "paths": {
+        "/home/getDashboardChartData": {
+            "get": {
+                "description": "Get data of each chart on dashboard by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "home"
+                ],
+                "summary": "Get data of each chart on dashboard",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/domain.DashboardChartDataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot get data for all charts.",
+                        "schema": {
+                            "$ref": "#/definitions/http.response"
+                        }
+                    }
+                }
+            }
+        },
         "/home/getTopProducts": {
             "post": {
                 "description": "Get top products to display in the intelligent dashboard by user ID",
@@ -1039,6 +1077,23 @@
                 }
             }
         },
+        "domain.CostRevenueChartItem": {
+            "type": "object",
+            "properties": {
+                "cost": {
+                    "type": "number"
+                },
+                "month": {
+                    "type": "string"
+                },
+                "net_profit": {
+                    "type": "number"
+                },
+                "revenue": {
+                    "type": "number"
+                }
+            }
+        },
         "domain.CreateNotificationItem": {
             "type": "object",
             "properties": {
@@ -1065,6 +1120,29 @@
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "domain.DashboardChartDataResponse": {
+            "type": "object",
+            "properties": {
+                "cost_revenue": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.CostRevenueChartItem"
+                    }
+                },
+                "net_profit": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.NetProfitChartItem"
+                    }
+                },
+                "profit_threshold": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.ProfitThresholdChartItem"
+                    }
                 }
             }
         },
@@ -1303,6 +1381,17 @@
                 }
             }
         },
+        "domain.NetProfitChartItem": {
+            "type": "object",
+            "properties": {
+                "month": {
+                    "type": "string"
+                },
+                "profit": {
+                    "type": "number"
+                }
+            }
+        },
         "domain.NotificationItem": {
             "type": "object",
             "properties": {
@@ -1331,6 +1420,17 @@
                     "items": {
                         "$ref": "#/definitions/domain.NotificationItem"
                     }
+                }
+            }
+        },
+        "domain.ProfitThresholdChartItem": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "threshold": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -71,6 +71,41 @@ definitions:
       yellow_expiration_date:
         type: integer
     type: object
+  domain.FilterItemResponse:
+    properties:
+      detail:
+        type: string
+      name:
+        type: string
+      url:
+        type: string
+    type: object
+  domain.FilterProductResponse:
+    properties:
+      products:
+        items:
+          $ref: '#/definitions/domain.FilterItemResponse'
+        type: array
+    type: object
+  domain.FilterSellingRequest:
+    properties:
+      filter_type:
+        type: string
+      order_types:
+        items:
+          type: string
+        type: array
+      sales_channel:
+        items:
+          type: string
+        type: array
+      sort_type:
+        type: string
+      unit_type:
+        type: string
+      user_id:
+        type: string
+    type: object
   domain.FixCostSetting:
     properties:
       advertising:
@@ -267,6 +302,8 @@ definitions:
         type: integer
       sell_by_date:
         type: string
+      stock_detail_id:
+        type: string
     type: object
   domain.StockItem:
     properties:
@@ -321,6 +358,33 @@ info:
   title: BakingUp Backend API
   version: "1.0"
 paths:
+  /home/getTopProducts:
+    post:
+      consumes:
+      - application/json
+      description: Get top products to display in the intelligent dashboard by user
+        ID
+      parameters:
+      - description: Filter Request
+        in: body
+        name: filter_request
+        required: true
+        schema:
+          $ref: '#/definitions/domain.FilterSellingRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/domain.FilterProductResponse'
+        "400":
+          description: Cannot get the filter response.
+          schema:
+            $ref: '#/definitions/http.response'
+      summary: Get top products to display in the intelligent dashboard
+      tags:
+      - home
   /home/getUnreadNotification:
     get:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -43,6 +43,17 @@ definitions:
       user_id:
         type: string
     type: object
+  domain.CostRevenueChartItem:
+    properties:
+      cost:
+        type: number
+      month:
+        type: string
+      net_profit:
+        type: number
+      revenue:
+        type: number
+    type: object
   domain.CreateNotificationItem:
     properties:
       created_at:
@@ -61,6 +72,21 @@ definitions:
         type: string
       user_id:
         type: string
+    type: object
+  domain.DashboardChartDataResponse:
+    properties:
+      cost_revenue:
+        items:
+          $ref: '#/definitions/domain.CostRevenueChartItem'
+        type: array
+      net_profit:
+        items:
+          $ref: '#/definitions/domain.NetProfitChartItem'
+        type: array
+      profit_threshold:
+        items:
+          $ref: '#/definitions/domain.ProfitThresholdChartItem'
+        type: array
     type: object
   domain.ExpirationDateSetting:
     properties:
@@ -215,6 +241,13 @@ definitions:
       user_id:
         type: string
     type: object
+  domain.NetProfitChartItem:
+    properties:
+      month:
+        type: string
+      profit:
+        type: number
+    type: object
   domain.NotificationItem:
     properties:
       created_at:
@@ -234,6 +267,13 @@ definitions:
         items:
           $ref: '#/definitions/domain.NotificationItem'
         type: array
+    type: object
+  domain.ProfitThresholdChartItem:
+    properties:
+      name:
+        type: string
+      threshold:
+        type: number
     type: object
   domain.RecipeDetail:
     properties:
@@ -358,6 +398,31 @@ info:
   title: BakingUp Backend API
   version: "1.0"
 paths:
+  /home/getDashboardChartData:
+    get:
+      consumes:
+      - application/json
+      description: Get data of each chart on dashboard by user ID
+      parameters:
+      - description: User ID
+        in: query
+        name: user_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/domain.DashboardChartDataResponse'
+        "400":
+          description: Cannot get data for all charts.
+          schema:
+            $ref: '#/definitions/http.response'
+      summary: Get data of each chart on dashboard
+      tags:
+      - home
   /home/getTopProducts:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -253,6 +253,11 @@ definitions:
           $ref: '#/definitions/domain.StockItem'
         type: array
     type: object
+  domain.UnreadNotification:
+    properties:
+      unread_noti_amount:
+        type: integer
+    type: object
   domain.UserLanguage:
     properties:
       language:
@@ -277,6 +282,31 @@ info:
   title: BakingUp Backend API
   version: "1.0"
 paths:
+  /home/getUnreadNotification:
+    get:
+      consumes:
+      - application/json
+      description: Get unread notification amount of user by user ID
+      parameters:
+      - description: User ID
+        in: query
+        name: user_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/domain.UnreadNotification'
+        "400":
+          description: Cannot get unread notification amount.
+          schema:
+            $ref: '#/definitions/http.response'
+      summary: Get unread notification amount of user
+      tags:
+      - home
   /ingredient/deleteIngredient:
     delete:
       consumes:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.6
 require (
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/gofiber/swagger v1.1.0
+	github.com/google/uuid v1.5.0
 	github.com/joho/godotenv v1.5.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/steebchen/prisma-client-go v0.38.0
@@ -18,7 +19,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/spec v0.20.11 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/internal/adapter/handler/http/home.go
+++ b/internal/adapter/handler/http/home.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
 	"github.com/BakingUp/BakingUp-Backend/internal/core/service"
 	"github.com/gofiber/fiber/v2"
 )
@@ -35,5 +36,48 @@ func (hh *HomeHandler) GetUnreadNotification(c *fiber.Ctx) error {
 	}
 
 	handleSuccess(c, unreadNotificationAmount)
+	return nil
+}
+
+// GetTopProducts godoc
+// @Summary      Get top products to display in the intelligent dashboard
+// @Description  Get top products to display in the intelligent dashboard by user ID
+// @Tags         home
+// @Accept       json
+// @Produce      json
+// @Param        filter_request  body  domain.FilterSellingRequest  true  "Filter Request"
+// @Success      200  {object}  domain.FilterProductResponse  "Success"
+// @Failure      400  {object}  response     "Cannot get the filter response."
+// @Router       /home/getTopProducts [post]
+func (hh *HomeHandler) GetTopProducts(c *fiber.Ctx) error {
+	var filterRequest domain.FilterSellingRequest
+
+	if err := c.BodyParser(&filterRequest); err != nil {
+		handleError(c, 400, "Failed to parse request body", err.Error())
+		return nil
+	}
+
+	if filterRequest.UserID == "" {
+		handleError(c, 400, "UserID is required", "")
+		return nil
+	}
+
+	var filterResponse *domain.FilterProductResponse
+	var err error
+	if filterRequest.FilterType != "Wasted Ingredients" && filterRequest.FilterType != "Wasted Bakery Stock" {
+		filterResponse, err = hh.homeService.GetTopProducts(c, filterRequest.UserID, filterRequest.FilterType, filterRequest.SalesChannel, filterRequest.OrderTypes)
+		if err != nil {
+			handleError(c, 400, "Cannot get the filter response.", err.Error())
+			return nil
+		}
+	} else {
+		filterResponse, err = hh.homeService.GetWastedProduct(c, filterRequest.UserID, filterRequest.FilterType, filterRequest.UnitType, filterRequest.SortType)
+		if err != nil {
+			handleError(c, 400, "Cannot get the filter response.", err.Error())
+			return nil
+		}
+	}
+
+	handleSuccess(c, filterResponse)
 	return nil
 }

--- a/internal/adapter/handler/http/home.go
+++ b/internal/adapter/handler/http/home.go
@@ -81,3 +81,26 @@ func (hh *HomeHandler) GetTopProducts(c *fiber.Ctx) error {
 	handleSuccess(c, filterResponse)
 	return nil
 }
+
+// GetDashboardChartData godoc
+// @Summary      Get data of each chart on dashboard
+// @Description  Get data of each chart on dashboard by user ID
+// @Tags         home
+// @Accept       json
+// @Produce      json
+// @Param        user_id  query string  true  "User ID"
+// @Success      200  {object}  domain.DashboardChartDataResponse  "Success"
+// @Failure      400  {object}  response     "Cannot get data for all charts."
+// @Router       /home/getDashboardChartData [get]
+func (hh *HomeHandler) GetDashboardChartData(c *fiber.Ctx) error {
+	userID := c.Query("user_id")
+
+	response, err := hh.homeService.GetDashboardChartData(c, userID)
+	if err != nil {
+		handleError(c, 400, "Cannot get data for all charts.", err.Error())
+		return nil
+	}
+
+	handleSuccess(c, response)
+	return nil
+}

--- a/internal/adapter/handler/http/home.go
+++ b/internal/adapter/handler/http/home.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"github.com/BakingUp/BakingUp-Backend/internal/core/service"
+	"github.com/gofiber/fiber/v2"
+)
+
+type HomeHandler struct {
+	homeService *service.HomeService
+}
+
+func NewHomeHandler(homeService *service.HomeService) *HomeHandler {
+	return &HomeHandler{
+		homeService: homeService,
+	}
+}
+
+// GetUnreadNotification godoc
+// @Summary      Get unread notification amount of user
+// @Description  Get unread notification amount of user by user ID
+// @Tags         home
+// @Accept       json
+// @Produce      json
+// @Param        user_id  query  string  true  "User ID"
+// @Success      200  {object}  domain.UnreadNotification  "Success"
+// @Failure      400  {object}  response     "Cannot get unread notification amount."
+// @Router       /home/getUnreadNotification [get]
+func (hh *HomeHandler) GetUnreadNotification(c *fiber.Ctx) error {
+	userID := c.Query("user_id")
+
+	unreadNotificationAmount, err := hh.homeService.GetUnreadNotification(c, userID)
+	if err != nil {
+		handleError(c, 400, "Cannot get unread notification amount.", err.Error())
+		return nil
+	}
+
+	handleSuccess(c, unreadNotificationAmount)
+	return nil
+}

--- a/internal/adapter/handler/http/router.go
+++ b/internal/adapter/handler/http/router.go
@@ -9,7 +9,7 @@ type Router struct {
 	router fiber.Router
 }
 
-func NewRouter(a *fiber.App, ingredientHandler IngredientHandler, recipeHandler RecipeHandler, authHandler AuthHandler, stockHandler StockHandler, userHandler UserHandler, orderHandler OrderHandler, settingsHandler SettingsHandler) (*Router, error) {
+func NewRouter(a *fiber.App, ingredientHandler IngredientHandler, recipeHandler RecipeHandler, authHandler AuthHandler, stockHandler StockHandler, userHandler UserHandler, orderHandler OrderHandler, settingsHandler SettingsHandler, homeHandler HomeHandler) (*Router, error) {
 	a.Get("/swagger/*", swagger.HandlerDefault)
 
 	api := a.Group("/api")
@@ -26,6 +26,12 @@ func NewRouter(a *fiber.App, ingredientHandler IngredientHandler, recipeHandler 
 			auth.Delete("/deleteDeviceToken", authHandler.DeleteDeviceToken)
 			auth.Delete("/deleteAllExceptDeviceToken", authHandler.DeleteAllExceptDeviceToken)
 		}
+
+		home := api.Group("/home")
+		{
+			home.Get("getUnreadNotification", homeHandler.GetUnreadNotification)
+		}
+
 		ingredient := api.Group("/ingredient")
 		{
 			ingredient.Get("/getAllIngredients", ingredientHandler.GetAllIngredients)

--- a/internal/adapter/handler/http/router.go
+++ b/internal/adapter/handler/http/router.go
@@ -29,8 +29,9 @@ func NewRouter(a *fiber.App, ingredientHandler IngredientHandler, recipeHandler 
 
 		home := api.Group("/home")
 		{
-			home.Get("getUnreadNotification", homeHandler.GetUnreadNotification)
-			home.Post("getTopProducts", homeHandler.GetTopProducts)
+			home.Get("/getUnreadNotification", homeHandler.GetUnreadNotification)
+			home.Post("/getTopProducts", homeHandler.GetTopProducts)
+			home.Get("/getDashboardChartData", homeHandler.GetDashboardChartData)
 		}
 
 		ingredient := api.Group("/ingredient")

--- a/internal/adapter/handler/http/router.go
+++ b/internal/adapter/handler/http/router.go
@@ -30,6 +30,7 @@ func NewRouter(a *fiber.App, ingredientHandler IngredientHandler, recipeHandler 
 		home := api.Group("/home")
 		{
 			home.Get("getUnreadNotification", homeHandler.GetUnreadNotification)
+			home.Post("getTopProducts", homeHandler.GetTopProducts)
 		}
 
 		ingredient := api.Group("/ingredient")

--- a/internal/adapter/storage/postgres/repository/home.go
+++ b/internal/adapter/storage/postgres/repository/home.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"strconv"
+
+	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
+	"github.com/BakingUp/BakingUp-Backend/prisma/db"
+	"github.com/gofiber/fiber/v2"
+)
+
+type HomeRepository struct {
+	db *db.PrismaClient
+}
+
+func NewHomeRepository(db *db.PrismaClient) *HomeRepository {
+	return &HomeRepository{
+		db,
+	}
+}
+
+func (hr *HomeRepository) GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error) {
+	var unReadNotificationAmount domain.UnreadNotification
+	var result []map[string]string
+	err := hr.db.Prisma.QueryRaw(`SELECT COUNT(*)  FROM "Notifications" WHERE user_id = $1 AND is_read = $2`, userID, false).Exec(c.Context(), &result)
+	if err != nil {
+		return nil, err
+	}
+	count, _ := strconv.Atoi(result[0]["count"])
+
+	unReadNotificationAmount.UnreadNotiAmount = count
+	return &unReadNotificationAmount, nil
+}

--- a/internal/adapter/storage/postgres/repository/home.go
+++ b/internal/adapter/storage/postgres/repository/home.go
@@ -73,3 +73,17 @@ func (hr *HomeRepository) GetTopWastedStock(c *fiber.Ctx, userID string) ([]db.R
 
 	return recipes, nil
 }
+
+func (hr *HomeRepository) GetDashboardChartData(c *fiber.Ctx, userID string) ([]db.RecipesModel, error) {
+	recipes, err := hr.db.Recipes.FindMany(
+		db.Recipes.UserID.Equals(userID),
+	).With(
+		db.Recipes.OrderProducts.Fetch().With(db.OrderProducts.Order.Fetch()),
+		db.Recipes.Stocks.Fetch(),
+	).Exec(c.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	return recipes, nil
+}

--- a/internal/core/domain/home.go
+++ b/internal/core/domain/home.go
@@ -3,3 +3,32 @@ package domain
 type UnreadNotification struct {
 	UnreadNotiAmount int `json:"unread_noti_amount"`
 }
+
+type FilterSellingRequest struct {
+	UserID       string   `json:"user_id"`
+	FilterType   string   `json:"filter_type"`
+	SalesChannel []string `json:"sales_channel,omitempty"`
+	OrderTypes   []string `json:"order_types,omitempty"`
+	UnitType     string   `json:"unit_type,omitempty"`
+	SortType     string   `json:"sort_type,omitempty"`
+}
+
+type FilterWastedRequest struct {
+	UserID     string `json:"user_id"`
+	FilterType string `json:"filter_type"`
+}
+
+type FilterProductResponse struct {
+	Products []FilterItemResponse `json:"products"`
+}
+
+type FilterItemResponse struct {
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Detail string `json:"detail"`
+}
+
+type ProductPricing struct {
+	SellingPrice float64 `json:"selling_price"`
+	Cost         float64 `json:"cost"`
+}

--- a/internal/core/domain/home.go
+++ b/internal/core/domain/home.go
@@ -32,3 +32,26 @@ type ProductPricing struct {
 	SellingPrice float64 `json:"selling_price"`
 	Cost         float64 `json:"cost"`
 }
+
+type DashboardChartDataResponse struct {
+	CostRevenue     []CostRevenueChartItem     `json:"cost_revenue"`
+	NetProfit       []NetProfitChartItem       `json:"net_profit"`
+	ProfitThreshold []ProfitThresholdChartItem `json:"profit_threshold"`
+}
+
+type CostRevenueChartItem struct {
+	Month     string  `json:"month"`
+	Revenue   float64 `json:"revenue"`
+	Cost      float64 `json:"cost"`
+	NetProfit float64 `json:"net_profit"`
+}
+
+type NetProfitChartItem struct {
+	Month  string  `json:"month"`
+	Profit float64 `json:"profit"`
+}
+
+type ProfitThresholdChartItem struct {
+	Name      string  `json:"name"`
+	Threshold float64 `json:"threshold"`
+}

--- a/internal/core/domain/home.go
+++ b/internal/core/domain/home.go
@@ -1,0 +1,5 @@
+package domain
+
+type UnreadNotification struct {
+	UnreadNotiAmount int `json:"unread_noti_amount"`
+}

--- a/internal/core/port/home.go
+++ b/internal/core/port/home.go
@@ -2,13 +2,18 @@ package port
 
 import (
 	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
+	"github.com/BakingUp/BakingUp-Backend/prisma/db"
 	"github.com/gofiber/fiber/v2"
 )
 
 type HomeRepository interface {
 	GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error)
+	GetTopProducts(c *fiber.Ctx, userID string, saleChannels []string, orderTypes []string) ([]db.OrdersModel, error)
+	GetTopWastedStock(c *fiber.Ctx, userID string) ([]db.RecipesModel, error)
 }
 
 type HomeService interface {
 	GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error)
+	GetTopProducts(c *fiber.Ctx, userID string, chartType string, saleChannels []string, orderTypes []string) (*domain.FilterProductResponse, error)
+	GetWastedProduct(c *fiber.Ctx, userID string, chartType string, productType string, sortType string) (*domain.FilterProductResponse, error)
 }

--- a/internal/core/port/home.go
+++ b/internal/core/port/home.go
@@ -10,10 +10,12 @@ type HomeRepository interface {
 	GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error)
 	GetTopProducts(c *fiber.Ctx, userID string, saleChannels []string, orderTypes []string) ([]db.OrdersModel, error)
 	GetTopWastedStock(c *fiber.Ctx, userID string) ([]db.RecipesModel, error)
+	GetDashboardChartData(c *fiber.Ctx, userID string) ([]db.RecipesModel, error)
 }
 
 type HomeService interface {
 	GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error)
 	GetTopProducts(c *fiber.Ctx, userID string, chartType string, saleChannels []string, orderTypes []string) (*domain.FilterProductResponse, error)
 	GetWastedProduct(c *fiber.Ctx, userID string, chartType string, productType string, sortType string) (*domain.FilterProductResponse, error)
+	GetDashboardChartData(c *fiber.Ctx, userID string) (*domain.DashboardChartDataResponse, error)
 }

--- a/internal/core/port/home.go
+++ b/internal/core/port/home.go
@@ -1,0 +1,14 @@
+package port
+
+import (
+	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
+	"github.com/gofiber/fiber/v2"
+)
+
+type HomeRepository interface {
+	GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error)
+}
+
+type HomeService interface {
+	GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error)
+}

--- a/internal/core/service/home.go
+++ b/internal/core/service/home.go
@@ -274,7 +274,6 @@ func (hs *HomeService) GetDashboardChartData(c *fiber.Ctx, userID string) (*doma
 				profit := (stock.SellingPrice - stock.Cost) * float64(orderProduct.ProductQuantity)
 
 				_, ok1 := costRevenueData[month]
-				// _, ok2 := netProfit[month]
 				if ok1 {
 					costRevenueData[month] = domain.CostRevenueChartItem{
 						Month:     month,
@@ -291,11 +290,6 @@ func (hs *HomeService) GetDashboardChartData(c *fiber.Ctx, userID string) (*doma
 						NetProfit: profit - fixCost,
 					}
 
-					// netProfitItem := domain.NetProfitChartItem{
-					// 	Month:  month,
-					// 	Profit: profit - fixCost,
-					// }
-					// netProfit[month] = netProfitItem
 					costRevenueData[month] = costRevenueItem
 				}
 				recipeProfit += profit

--- a/internal/core/service/home.go
+++ b/internal/core/service/home.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
+	"github.com/BakingUp/BakingUp-Backend/internal/core/port"
+	"github.com/gofiber/fiber/v2"
+)
+
+type HomeService struct {
+	homeRepo    port.HomeRepository
+	userService port.UserService
+}
+
+func NewHomeService(homeRepo port.HomeRepository, userService port.UserService) *HomeService {
+	return &HomeService{
+		homeRepo:    homeRepo,
+		userService: userService,
+	}
+}
+
+func (hs *HomeService) GetUnreadNotification(c *fiber.Ctx, userID string) (*domain.UnreadNotification, error) {
+	unreadNotiAmount, err := hs.homeRepo.GetUnreadNotification(c, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return unreadNotiAmount, nil
+}

--- a/internal/core/service/home.go
+++ b/internal/core/service/home.go
@@ -1,20 +1,31 @@
 package service
 
 import (
+	"fmt"
+	"sort"
+	"time"
+
 	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
 	"github.com/BakingUp/BakingUp-Backend/internal/core/port"
+	"github.com/BakingUp/BakingUp-Backend/internal/core/util"
 	"github.com/gofiber/fiber/v2"
 )
 
 type HomeService struct {
-	homeRepo    port.HomeRepository
-	userService port.UserService
+	homeRepo       port.HomeRepository
+	userService    port.UserService
+	settingService port.SettingsService
+	recipeRepo     port.RecipeRepository
+	ingredientRepo port.IngredientRepository
 }
 
-func NewHomeService(homeRepo port.HomeRepository, userService port.UserService) *HomeService {
+func NewHomeService(homeRepo port.HomeRepository, userService port.UserService, settingService port.SettingsService, recipeRepo port.RecipeRepository, ingredientRepo port.IngredientRepository) *HomeService {
 	return &HomeService{
-		homeRepo:    homeRepo,
-		userService: userService,
+		homeRepo:       homeRepo,
+		userService:    userService,
+		settingService: settingService,
+		recipeRepo:     recipeRepo,
+		ingredientRepo: ingredientRepo,
 	}
 }
 
@@ -25,4 +36,191 @@ func (hs *HomeService) GetUnreadNotification(c *fiber.Ctx, userID string) (*doma
 	}
 
 	return unreadNotiAmount, nil
+}
+
+func (hs *HomeService) GetTopProducts(c *fiber.Ctx, userID string, chartType string, saleChannels []string, orderTypes []string) (*domain.FilterProductResponse, error) {
+	orders, err := hs.homeRepo.GetTopProducts(c, userID, saleChannels, orderTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	language, err := hs.userService.GetUserLanguage(c, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the map
+	product := make(map[string]int)
+	var productList []domain.FilterItemResponse
+	productSellingPrice := make(map[string]domain.ProductPricing)
+
+	for _, order := range orders {
+
+		for _, orderProductItem := range order.OrderProducts() {
+			recipeName := util.GetRecipeName(orderProductItem.Recipe(), language)
+
+			if _, ok := product[recipeName]; ok {
+				product[recipeName] += orderProductItem.ProductQuantity
+			} else {
+				product[recipeName] = orderProductItem.ProductQuantity
+				for _, image := range orderProductItem.Recipe().RecipeImages() {
+					if image.RecipeID == orderProductItem.RecipeID {
+						productList = append(productList, domain.FilterItemResponse{
+							Name: recipeName,
+							URL:  image.RecipeURL,
+						})
+						break
+					}
+				}
+			}
+			if stock, ok := orderProductItem.Recipe().Stocks(); ok {
+				productSellingPrice[recipeName] = domain.ProductPricing{
+					SellingPrice: stock.SellingPrice,
+					Cost:         stock.Cost,
+				}
+			}
+		}
+	}
+
+	fixCost, _ := hs.settingService.GetFixCost(c, userID)
+	var response domain.FilterProductResponse
+	for i := 0; i < len(productList); i++ {
+		name := productList[i].Name
+		quantity := product[name]
+		if chartType == "Best Selling" || chartType == "Worst Selling" {
+			productList[i].Detail = fmt.Sprintf("%d items sold", quantity)
+		} else if chartType == "Top Profit Ratio" || chartType == "Top Profit Revenue" || chartType == "Top Profit Margin" {
+			profitRevenue := productSellingPrice[name].SellingPrice * float64(quantity)
+			profitProducts := (productSellingPrice[name].SellingPrice - productSellingPrice[name].Cost) * float64(quantity)
+			profitMargin := ((profitRevenue - profitProducts) / profitRevenue) * 100
+			allFixCost := fixCost.Rent + fixCost.Salaries + fixCost.Insurance + fixCost.Subscriptions + fixCost.Advertising + fixCost.Electricity + fixCost.Water + fixCost.Gas + fixCost.Other
+			profitRatio := ((profitProducts - allFixCost) / profitRevenue) * 100
+			switch chartType {
+			case "Top Profit Revenue":
+				productList[i].Detail = fmt.Sprintf("%.2f baht", profitRevenue)
+			case "Top Profit Margin":
+				productList[i].Detail = fmt.Sprintf("Profit Margin: %.2f%%", profitMargin)
+			case "Top Profit Ratio":
+				productList[i].Detail = fmt.Sprintf("Profit Ratio: %.2f%%", profitRatio)
+			}
+		}
+		// else if chartType == "Selling Quickly" {
+
+		// }
+
+	}
+
+	if chartType != "Worst Selling" {
+		sort.SliceStable(productList, func(i, j int) bool {
+			return productList[i].Detail > productList[j].Detail
+		})
+	} else {
+		sort.SliceStable(productList, func(i, j int) bool {
+			return productList[i].Detail < productList[j].Detail
+		})
+	}
+
+	response = domain.FilterProductResponse{
+		Products: productList,
+	}
+
+	return &response, nil
+}
+
+func (hs *HomeService) GetWastedProduct(c *fiber.Ctx, userID string, filterType string, unitType string, sortType string) (*domain.FilterProductResponse, error) {
+	var productList []domain.FilterItemResponse
+
+	language, err := hs.userService.GetUserLanguage(c, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if filterType == "Wasted Ingredients" {
+		ingredientList, err := hs.ingredientRepo.GetAllIngredients(c, userID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ingredient := range ingredientList {
+			name := util.GetIngredientName(&ingredient, language)
+			var productAmount float64
+			var productItem domain.FilterItemResponse
+
+			if unitType == "Solid" && (ingredient.Unit == "G" || ingredient.Unit == "KG") {
+				productItem.Name = name
+				for _, ingredientItem := range ingredient.IngredientDetail() {
+					if ingredientItem.ExpirationDate.Before(time.Now()) && ingredient.Unit == "KG" {
+						productAmount += ingredientItem.IngredientQuantity
+					} else if ingredientItem.ExpirationDate.Before(time.Now()) {
+						productAmount += ingredientItem.IngredientQuantity / 1000
+					}
+				}
+			} else if unitType == "Liquid" && (ingredient.Unit == "ML" || ingredient.Unit == "L") {
+				for _, ingredientItem := range ingredient.IngredientDetail() {
+
+					if ingredientItem.ExpirationDate.Before(time.Now()) && ingredient.Unit == "L" {
+						productAmount += ingredientItem.IngredientQuantity
+					} else if ingredientItem.ExpirationDate.Before(time.Now()) {
+						productAmount += ingredientItem.IngredientQuantity / 1000
+					}
+				}
+			}
+			images := ingredient.IngredientImages()
+			if len(images) > 0 {
+				productItem.URL = images[0].IngredientURL
+			}
+			if unitType == "Solid" {
+				productItem.Detail = fmt.Sprintf("Wasted Item: %.3f kg", productAmount)
+			} else {
+				productItem.Detail = fmt.Sprintf("Wasted Item: %.3f l", productAmount)
+			}
+			productList = append(productList, productItem)
+		}
+	} else {
+		recipes, err := hs.homeRepo.GetTopWastedStock(c, userID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, recipe := range recipes {
+			var productAmount int
+			var productItem domain.FilterItemResponse
+			name := util.GetRecipeName(&recipe, language)
+			productItem.Name = name
+
+			if stock, ok := recipe.Stocks(); ok {
+				for _, stockItem := range stock.StockDetail() {
+					expiredDate := stockItem.CreatedAt.AddDate(0, 0, stock.DayBeforeExpired.Day())
+					if expiredDate.Before(time.Now()) {
+						productAmount += stockItem.Quantity
+					}
+
+				}
+			}
+
+			images := recipe.RecipeImages()
+			if len(images) > 0 {
+				productItem.URL = images[0].RecipeURL
+			}
+			productItem.Detail = fmt.Sprintf("Wasted Item: %d", productAmount)
+			productList = append(productList, productItem)
+		}
+	}
+
+	if sortType == "Ascending" {
+		sort.SliceStable(productList, func(i, j int) bool {
+			return productList[i].Detail < productList[j].Detail
+		})
+	} else if sortType == "Descending" {
+		sort.SliceStable(productList, func(i, j int) bool {
+			return productList[i].Detail > productList[j].Detail
+		})
+	}
+
+	response := &domain.FilterProductResponse{
+		Products: productList,
+	}
+
+	return response, nil
+
 }

--- a/internal/core/service/home.go
+++ b/internal/core/service/home.go
@@ -217,8 +217,12 @@ func (hs *HomeService) GetWastedProduct(c *fiber.Ctx, userID string, filterType 
 		})
 	}
 
+	topProducts := productList
+	if len(productList) > 5 {
+		topProducts = productList[:5]
+	}
 	response := &domain.FilterProductResponse{
-		Products: productList,
+		Products: topProducts,
 	}
 
 	return response, nil

--- a/internal/core/service/home.go
+++ b/internal/core/service/home.go
@@ -3,7 +3,9 @@ package service
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/BakingUp/BakingUp-Backend/internal/core/domain"
@@ -111,13 +113,33 @@ func (hs *HomeService) GetTopProducts(c *fiber.Ctx, userID string, chartType str
 
 	}
 
+	re := regexp.MustCompile(`[-+]?\d*\.?\d+`)
+
 	if chartType != "Worst Selling" {
-		sort.SliceStable(productList, func(i, j int) bool {
-			return productList[i].Detail > productList[j].Detail
+		sort.Slice(productList, func(i, j int) bool {
+			// Extract and convert the numeric value from Detail for product i
+			detailI := re.FindString(productList[i].Detail)
+			valueI, _ := strconv.ParseFloat(detailI, 64)
+
+			// Extract and convert the numeric value from Detail for product j
+			detailJ := re.FindString(productList[j].Detail)
+			valueJ, _ := strconv.ParseFloat(detailJ, 64)
+
+			// Compare the values
+			return valueI > valueJ
 		})
 	} else {
-		sort.SliceStable(productList, func(i, j int) bool {
-			return productList[i].Detail < productList[j].Detail
+		sort.Slice(productList, func(i, j int) bool {
+			// Extract and convert the numeric value from Detail for product i
+			detailI := re.FindString(productList[i].Detail)
+			valueI, _ := strconv.ParseFloat(detailI, 64)
+
+			// Extract and convert the numeric value from Detail for product j
+			detailJ := re.FindString(productList[j].Detail)
+			valueJ, _ := strconv.ParseFloat(detailJ, 64)
+
+			// Compare the values
+			return valueI < valueJ
 		})
 	}
 


### PR DESCRIPTION
#All home endpoints
## Get unread notification
<img width="1069" alt="Screenshot 2567-10-09 at 14 37 26" src="https://github.com/user-attachments/assets/32caa5c3-2990-4722-b1d8-e56b386f67a4">

## Get Top Products (not include Selling-Quickly filtering)
### Best-Selling
#### Request
<img width="1068" alt="Screenshot 2567-10-09 at 14 58 05" src="https://github.com/user-attachments/assets/a37b823d-635e-4251-83d5-a2ec952f3a98">

#### Response
<img width="1059" alt="Screenshot 2567-10-09 at 15 03 25" src="https://github.com/user-attachments/assets/89a3579d-ad54-4490-9f9c-e6865e1ec152">

### Worst-Selling
#### Request
<img width="1071" alt="Screenshot 2567-10-09 at 15 29 29" src="https://github.com/user-attachments/assets/cc36182c-f06e-4b9d-9fc7-3c2d2b1b2537">

#### Response
<img width="1066" alt="Screenshot 2567-10-09 at 15 29 36" src="https://github.com/user-attachments/assets/c59f9bc5-9b8b-45c8-9451-85c5ab7fce84">

### Top Profit Ratio
#### Request
<img width="1069" alt="Screenshot 2567-10-09 at 15 35 57" src="https://github.com/user-attachments/assets/2b8f2791-6b85-4a8c-9702-d9e9910b5e2f">

#### Response
<img width="1058" alt="Screenshot 2567-10-09 at 15 45 19" src="https://github.com/user-attachments/assets/bf97f545-b314-4b53-a77d-72391e207541">

### Top Profit Revenue
#### Request
<img width="1069" alt="Screenshot 2567-10-09 at 15 48 00" src="https://github.com/user-attachments/assets/b44f3534-73cd-4dca-8fc4-c42dd7d567c2">

#### Response
<img width="1064" alt="Screenshot 2567-10-09 at 15 48 06" src="https://github.com/user-attachments/assets/21686605-08a5-4c93-929b-e31a926b9924">

### Top Profit Margin
#### Request
<img width="1073" alt="Screenshot 2567-10-09 at 15 49 01" src="https://github.com/user-attachments/assets/304afd34-0b3c-40a1-8669-da9b3c1d834c">

#### Response
<img width="1072" alt="Screenshot 2567-10-09 at 15 49 08" src="https://github.com/user-attachments/assets/fe11a7f0-60a0-4e83-b0c2-f7b04275aaf2">

### Wasted Ingredients (Solid & Liquid)
#### Request - Solid
<img width="1067" alt="Screenshot 2567-10-09 at 15 51 42" src="https://github.com/user-attachments/assets/f892cb61-88c2-416a-8621-d3c76956bbb6">

#### Response - Solid
<img width="1065" alt="Screenshot 2567-10-09 at 15 51 48" src="https://github.com/user-attachments/assets/74296056-7c42-44bc-b713-4f585736e0ae">

### Wasted Bakery Stock
#### Request
<img width="1068" alt="Screenshot 2567-10-09 at 15 54 16" src="https://github.com/user-attachments/assets/31d9c189-77fb-44eb-b5df-030495cf3576">

#### Response
<img width="1065" alt="Screenshot 2567-10-09 at 15 54 22" src="https://github.com/user-attachments/assets/d7a2d8f4-cb25-4b71-bafb-90b4f18929e0">

## Get dashboard chart data
### Request
<img width="1070" alt="Screenshot 2567-10-09 at 14 36 36" src="https://github.com/user-attachments/assets/86363e01-d8bf-490d-9b02-cd47d4efdda6">

### Response
```
{
  "status": 200,
  "message": "Success",
  "data": {
    "cost_revenue": [
      {
        "month": "August",
        "revenue": 2000,
        "cost": 1000,
        "net_profit": -1100
      },
      {
        "month": "September",
        "revenue": 452.5,
        "cost": 250,
        "net_profit": -1897.5
      },
      {
        "month": "October",
        "revenue": 5050,
        "cost": 3000,
        "net_profit": -50
      }
    ],
    "net_profit": [
      {
        "month": "August",
        "profit": -1100
      },
      {
        "month": "September",
        "profit": -1897.5
      },
      {
        "month": "October",
        "profit": -50
      }
    ],
    "profit_threshold": [
      {
        "name": "Cake1",
        "threshold": 33.82
      },
      {
        "name": "cake2",
        "threshold": 66.18
      }
    ]
  }
}
```
